### PR TITLE
Settings screen implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
+    implementation 'com.takisoft.fix:preference-v7:28.0.0.0'
     implementation 'android.arch.lifecycle:extensions:1.1.1'
 
     implementation 'org.koin:koin-android:1.0.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,10 +13,12 @@
         <activity android:name=".view.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".view.preference.PreferenceActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/MainActivity.kt
+++ b/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/MainActivity.kt
@@ -1,16 +1,18 @@
 package com.github.dlweatherhead.pomodorotimer.view
 
+import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.databinding.Observable
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.util.Log
+import android.support.v7.preference.PreferenceManager
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
 import com.github.dlweatherhead.pomodorotimer.R
 import com.github.dlweatherhead.pomodorotimer.databinding.ActivityMainBinding
 import com.github.dlweatherhead.pomodorotimer.utility.TimeFormatUtility
+import com.github.dlweatherhead.pomodorotimer.view.preference.PreferenceActivity
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class MainActivity : AppCompatActivity() {
@@ -34,6 +36,8 @@ class MainActivity : AppCompatActivity() {
         binding.timeFormatter = TimeFormatUtility()
         binding.timerButton.setOnClickListener { viewModel.handleTimerButtonClicked() }
         viewModel.showToastTrigger.addOnPropertyChangedCallback(showToastOnPropertyChangedCallback)
+
+        PreferenceManager.setDefaultValues(this, R.xml.app_preferences, false)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -43,8 +47,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         if (item?.itemId == R.id.action_preferences) {
-            // TODO: Navigate to settings screen
-            Log.e("MainActivity", "Action Preferences clicked!")
+            startActivity(Intent(this, PreferenceActivity::class.java))
         }
         return super.onOptionsItemSelected(item)
     }

--- a/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceActivity.kt
@@ -1,0 +1,19 @@
+package com.github.dlweatherhead.pomodorotimer.view.preference
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.github.dlweatherhead.pomodorotimer.R
+
+class PreferenceActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_preferences)
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.container, PreferenceFragment())
+                .commit()
+        }
+
+    }
+}

--- a/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceFragment.kt
+++ b/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceFragment.kt
@@ -1,0 +1,12 @@
+package com.github.dlweatherhead.pomodorotimer.view.preference
+
+import android.os.Bundle
+import com.github.dlweatherhead.pomodorotimer.R
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
+
+class PreferenceFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.app_preferences)
+    }
+
+}

--- a/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceFragment.kt
+++ b/app/src/main/java/com/github/dlweatherhead/pomodorotimer/view/preference/PreferenceFragment.kt
@@ -4,6 +4,13 @@ import android.os.Bundle
 import com.github.dlweatherhead.pomodorotimer.R
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
 
+/**
+ * Note: We are extending this fix class instead of the standard PreferenceFragmentCompat
+ *  because we cannot access the edit text directly to set style. This fix allows the edit text
+ *  style to be set within the layout file.
+ *  The future solution, to remove this dependency, would be to create custom Preferences, or create dialogs for entry.
+ *  TODO: Investigate custom Preferences, dialogs, etc. for capturing preferences.
+ */
 class PreferenceFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.app_preferences)

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.preference.PreferenceActivity" />

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="preference_pomodoro_timer_key">preference_pomodoro_timer_key</string>
+    <string name="preference_short_rest_key">preference_short_rest_key</string>
+    <string name="preference_long_rest_key">preference_long_rest_key</string>
+    <string name="preference_pomodoro_count_key">preference_pomodoro_count_key</string>
+    <string name="preference_feedback_key">preference_feedback_key</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,19 @@
 <resources>
     <string name="app_name">Pomodoro Timer</string>
+    <string name="menu_action_preferences_title">settings</string>
+
     <string name="pomodoro_start_timer_label">Start Timer</string>
     <string name="pomodoro_stop_timer_label">Stop Timer</string>
     <string name="pomodoro_finished_toast_text">"Time to take a break!"</string>
-    <string name="menu_action_preferences_title">settings</string>
+
+    <string name="preference_feedback_title">Send feedback</string>
+    <string name="preference_pomodoro_count_title">Pomodoro Count</string>
+    <string name="preference_pomodoro_long_rest_title">Pomodoro Long Rest Length</string>
+    <string name="preference_pomodoro_short_rest_title">Pomodoro Short Rest Length</string>
+    <string name="preference_pomodoro_timer_length_title">Pomodoro Timer Length</string>
+    <string name="preference_pomodoro_timer_length_summary">Set the length for a pomodoro timer</string>
+    <string name="preference_pomodoro_short_rest_summary">Set the length for the short rest duration</string>
+    <string name="preference_pomodoro_long_rest_summary">Set the length for the long rest duration</string>
+    <string name="preference_pomodoro_count_summary">Set the number of pomodoros before a long rest</string>
+    <string name="preference_feedback_summary">We would be grateful for your feedback for technical issues or feature suggestions</string>
 </resources>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -1,0 +1,41 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory>
+        <EditTextPreference
+            android:defaultValue="25:00"
+            android:inputType="time"
+            app:key="@string/preference_pomodoro_timer_key"
+            app:summary="@string/preference_pomodoro_timer_length_summary"
+            app:title="@string/preference_pomodoro_timer_length_title" />
+
+        <EditTextPreference
+            android:defaultValue="5:00"
+            android:inputType="time"
+            app:key="@string/preference_short_rest_key"
+            app:summary="@string/preference_pomodoro_short_rest_summary"
+            app:title="@string/preference_pomodoro_short_rest_title" />
+
+        <EditTextPreference
+            android:defaultValue="15:00"
+            android:inputType="time"
+            app:key="@string/preference_long_rest_key"
+            app:summary="@string/preference_pomodoro_long_rest_summary"
+            app:title="@string/preference_pomodoro_long_rest_title" />
+
+        <EditTextPreference
+            android:defaultValue="4"
+            android:inputType="numberDecimal"
+            app:key="@string/preference_pomodoro_count_key"
+            app:summary="@string/preference_pomodoro_count_summary"
+            app:title="@string/preference_pomodoro_count_title" />
+    </PreferenceCategory>
+
+    <PreferenceCategory>
+        <Preference
+            app:key="@string/preference_feedback_key"
+            app:summary="@string/preference_feedback_summary"
+            app:title="@string/preference_feedback_title" />
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
Implemented a Settings/Preferences screen to set pomodoro values.

- Can set values for pomodoro lenght, breaks (short and long), and
pomodoro count before taking a long break
- Implementation follows standard Android use of Preferences
- Activity and Fragment used to allows Preference Fragment reuse from
another context.